### PR TITLE
Reference a Pre-Existing Folder when Creating Media

### DIFF
--- a/src/Service/EasyMediaManager.php
+++ b/src/Service/EasyMediaManager.php
@@ -173,7 +173,7 @@ class EasyMediaManager
      * @throws NotFoundExceptionInterface
      * @throws ProviderNotFound
      */
-    public function createMedia($source, ?string $path = null, ?string $name = null): Media
+    public function createMedia($source, ?string $path = null, ?string $name = null, ?Folder $folder = null): Media
     {
         $class = $this->getHelper()->getMediaClassName();
         /** @var Media $entity */
@@ -183,9 +183,11 @@ class EasyMediaManager
             $entity->setName($this->helper->cleanName($name));
         }
 
-        $folder = $this->folderByPath($path);
-        if (false === $folder) {
-            $folder = $this->createFolder(basename($path), dirname($path));
+        if (! $folder) {
+            $folder = $this->folderByPath($path);
+            if (false === $folder) {
+                $folder = $this->createFolder(basename($path), dirname($path));
+            }
         }
 
         $entity->setFolder($folder ?: null);


### PR DESCRIPTION
The createMedia function now includes an optional argument for Folder. The main intention is to use this bundle with an existing folder and pass that into the creating media function. Specifically, we used this with Doctrine data fixtures. It would try to create a new folder everytime and fail to create the folder in Doctrine since it already exists. 